### PR TITLE
Implement Session-Based Favorites Management for Paintings

### DIFF
--- a/add-to-favorites.php
+++ b/add-to-favorites.php
@@ -1,0 +1,26 @@
+<?php
+session_start();
+
+// Check if required query parameters exist
+if (isset($_GET['PaintingID'], $_GET['ImageFileName'], $_GET['Title'])) {
+    $paintingID = $_GET['PaintingID'];
+    $imageFileName = $_GET['ImageFileName'];
+    $title = $_GET['Title'];
+
+    // Initialize favorites array in session if not already set
+    if (!isset($_SESSION['favorites'])) {
+        $_SESSION['favorites'] = [];
+    }
+
+    // Add the painting to the favorites list
+    $_SESSION['favorites'][] = [
+        'PaintingID' => $paintingID,
+        'ImageFileName' => $imageFileName,
+        'Title' => $title
+    ];
+}
+
+// Redirect back to the previous page or to a default page
+header('Location: viewFavorites.php');
+exit;
+?>

--- a/browse-paintings.php
+++ b/browse-paintings.php
@@ -50,8 +50,7 @@ $filter = "All Paintings [Top 20]";
               </div>        
               <div class="extra">
                 <a class="ui icon orange button" href="cart.php?id=<?php echo $work['PaintingID']; ?>"><i class="add to cart icon"></i></a>
-                <a class="ui icon button" href=""><i class="heart icon"></i></a>  
-              </div>        
+                <a class="ui icon button" href="addToFavorites.php?PaintingID=<?php echo $work['PaintingID']; ?>&ImageFileName=<?php echo $work['ImageFileName']; ?>&Title=<?php echo urlencode($work['Title']); ?>"><i class="heart icon"></i></a>              </div>        
             </div>      
           </li>
             

--- a/remove-favorites.php
+++ b/remove-favorites.php
@@ -1,0 +1,26 @@
+<?php
+// Start or resume the session to access or modify session data.
+session_start();
+
+// Check if the 'clear' query parameter is set and its value is 'true'.
+if (isset($_GET['clear']) && $_GET['clear'] === 'true') {
+    // If 'clear' is true, clear the favorites list by removing it from the session.
+    unset($_SESSION['favorites']);
+} 
+// Check if the 'PaintingID' query parameter is set.
+elseif (isset($_GET['PaintingID'])) {
+    $paintingID = $_GET['PaintingID']; // Retrieve the PaintingID from the query string.
+
+    // Ensure the favorites list exists in the session before attempting to modify it.
+    if (isset($_SESSION['favorites'])) {
+        // Filter the favorites list, keeping only items that do not match the provided PaintingID.
+        $_SESSION['favorites'] = array_filter($_SESSION['favorites'], function ($favorite) use ($paintingID) {
+            return $favorite['PaintingID'] != $paintingID; // Keep items where PaintingID does not match.
+        });
+    }
+}
+
+// Redirect the user back to the view-favorites.php page after the action is completed.
+header('Location: view-favorites.php');
+exit(); // Terminate the script to ensure the redirect is executed properly.
+?>

--- a/single-painting.php
+++ b/single-painting.php
@@ -3,7 +3,7 @@ include 'includes/data.inc.php';
 include 'includes/art-functions.inc.php';
 
 // TODO: start session
-
+session_start();
 // is there an ID passed?
 $id = 406;
 if (isset($_GET['id'])) {

--- a/view-favorites.php
+++ b/view-favorites.php
@@ -1,7 +1,8 @@
 <?php
+session_start();
 
-
-
+// Retrieve favorites from the session
+$favorites = isset($_SESSION['favorites']) ? $_SESSION['favorites'] : [];
 
 ?>
 
@@ -38,22 +39,29 @@
               <th>Action</th>
           </tr></thead>
           <tbody>
-              <?php 
-                /* // markup for sample favorite is as follows:
-                     <tr>
-                        <td><img src="images/art/square-medium/092040.jpg"></td>
-                        <td><a href="single-painting.php?id=369">Adoration in the Forest</a></td>
-                        <td><a class="ui small button" href="remove-favorites.php?id=369">Remove</a></td>
-                     </tr>
-                   // loop through all favorites and output a row for each one  
-                */
-              ?>
+                <?php foreach ($favorites as $favorite): ?>
+                  <tr>
+                      <td>
+                        <img src="images/art/square-medium/<?php echo htmlspecialchars($favorite['ImageFileName']); ?>.jpg" alt="<?php echo htmlspecialchars($favorite['Title']); ?>">
+                      </td>
+                      <td>
+                        <a href="single-painting.php?id=<?php echo htmlspecialchars($favorite['PaintingID']); ?>">
+                            <?php echo htmlspecialchars($favorite['Title']); ?>
+                        </a>
+                      </td>
+                      <td>
+                        <a class="ui small button" href="remove-favorites.php?PaintingID=<?php echo htmlspecialchars($favorite['PaintingID']); ?>">
+                            Remove
+                        </a>
+                      </td>
+                  </tr>
+              <?php endforeach; ?>
           </tbody>
           <tfoot class="full-width">
               <th colspan="3">
-                <a class="ui left floated small primary labeled icon button" href="remove-favorites.php">
-                  <i class="remove circle icon"></i> Remove All Favorites
-                </a>                  
+                <a class="ui left floated small primary labeled icon button" href="remove-favorites.php?clear=true">
+                    <i class="remove circle icon"></i> Remove All Favorites
+                </a>               
               </th>
           </tfoot>
          </table>


### PR DESCRIPTION
This pull request introduces functionality to manage user favorites for paintings using PHP sessions. It includes the creation of addToFavorites.php to add paintings to the favorites list, remove-favorites.php to remove them, and view-favorites.php to display the list in a table format with small images and titles. Additionally, it updates the header to show the count of favorite items. These changes ensure proper session handling, improving the user experience when interacting with their favorite paintings list.